### PR TITLE
Add Pagination

### DIFF
--- a/typing_project/blog/templates/blog/index.html
+++ b/typing_project/blog/templates/blog/index.html
@@ -22,4 +22,39 @@ Typing...
       </div>
     </article>
   {% endfor %}
+
+  <!-- Pagination -->
+  {% if is_paginated %}
+    {% if page_obj.has_previous %}
+      <a href="?page=1" class="btn btn-outline-info mb-4">
+        First
+      </a>
+      <a href="?page={{ page_obj.previous_page_number }}" class="btn btn-outline-info mb-4">
+        Previous
+      </a>
+    {% endif %}
+
+    {% for num in page_obj.paginator.page_range %}
+      {% if page_obj.number == num %}
+        <!-- Check for current page -->
+        <a href="?page={{ num }}" class="btn btn-info mb-4">
+          {{ num }}
+        </a>
+      <!-- Add filter (|) to check for 3 previous pages -->
+      {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
+      <a href="?page={{ num }}" class="btn btn-outline-info mb-4">
+        {{ num }}
+      </a>
+      {% endif %}
+    {% endfor %}
+
+    {% if page_obj.has_next %}
+      <a href="?page={{ page_obj.next_page_number }}" class="btn btn-outline-info mb-4">
+        Next
+      </a>
+      <a href="?page={{ page_obj.paginator.num_pages }}" class="btn btn-outline-info mb-4">
+        Last
+      </a>
+    {% endif %}
+  {% endif %}
 {% endblock body %}

--- a/typing_project/blog/templates/blog/post_detail.html
+++ b/typing_project/blog/templates/blog/post_detail.html
@@ -9,7 +9,7 @@ Post
     <img src="{{ object.author.profile.image.url }}" class="rounded-circle article-img" />
     <div class="media-body">
       <div class="article-metadata">
-        <a class="mr-2" href="#">{{ object.author }}</a>
+        <a class="mr-2" href="{% url 'user-posts' object.author.username %}">{{ object.author }}</a>
         <small class="text-muted">
           {{ object.date_posted|date:'j F Y, h:i a' }}
         </small>

--- a/typing_project/blog/templates/blog/user_posts.html
+++ b/typing_project/blog/templates/blog/user_posts.html
@@ -1,10 +1,14 @@
 {% extends 'blog/layout.html' %}
 
 {% block title %}
-Typing...
+Posts
 {% endblock title %}
 
 {% block body %}
+  <!-- Get username passed to url -->
+  <h1 class="mt-4 mb-4">
+    Posts by {{ view.kwargs.username }} ({{ page_obj.paginator.count }})
+  </h1>
   {% for post in posts %}
     <article class="media content-section">
       <img src="{{ post.author.profile.image.url }}" class="rounded-circle article-img" />

--- a/typing_project/blog/urls.py
+++ b/typing_project/blog/urls.py
@@ -1,6 +1,7 @@
 from . import views
 from django.urls import path
 from .views import (
+    UserPostListView,
     PostListView,
     PostDetailView,
     PostCreateView,
@@ -10,6 +11,7 @@ from .views import (
 
 urlpatterns = [
     path('', PostListView.as_view(), name="blog-index"),
+    path('user/<str:username>', UserPostListView.as_view(), name="user-posts"),
     path('post/<int:pk>/', PostDetailView.as_view(), name="post-detail"),
     path('post/new/', PostCreateView.as_view(), name="post-create"),
     path('post/<int:pk>/update/', PostUpdateView.as_view(), name="post-update"),

--- a/typing_project/blog/views.py
+++ b/typing_project/blog/views.py
@@ -1,5 +1,6 @@
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.contrib.auth.models import User
 from django.views.generic import (
     ListView,
     DetailView,
@@ -15,6 +16,20 @@ def index(request):
         'posts': Post.objects.all()
     }
     return render(request, 'blog/index.html', context)
+
+
+class UserPostListView(ListView):
+    model = Post
+    template_name = 'blog/user_posts.html'
+    context_object_name = 'posts'
+    paginate_by = 5
+
+    # Modify query set listview returns
+    def get_queryset(self):
+        # Return 404 error if user does not exist
+        # kwargs are query parameters
+        user = get_object_or_404(User, username=self.kwargs.get('username'))
+        return Post.objects.filter(author=user).order_by('-date_posted')
 
 
 class PostListView(ListView):

--- a/typing_project/blog/views.py
+++ b/typing_project/blog/views.py
@@ -27,6 +27,8 @@ class PostListView(ListView):
     context_object_name = 'posts'
     # Change order of posts (add - to reverse order, default is ascending)
     ordering = ['-date_posted']
+    # Set paginator: An integer specifying how many objects should be displayed per page
+    paginate_by = 5
 
 
 class PostDetailView(DetailView):


### PR DESCRIPTION
1. Limit the number of posts being displayed on the homepage
1. Add relevant pagination buttons for users to navigate through posts
1. Add individual posts view: when a user clicks on a username of a post
1. If an invalid username is given in url query for user posts, 404 error page is shown

**Homepage**
![image](https://user-images.githubusercontent.com/38811217/83963354-021bcc80-a8d8-11ea-87b7-afab1f342647.png)
![image](https://user-images.githubusercontent.com/38811217/83963369-29729980-a8d8-11ea-8be2-ea6c689a1706.png)


**User posts overview**
![image](https://user-images.githubusercontent.com/38811217/83963347-f4664700-a8d7-11ea-93a1-12b4073efc6c.png)
![image](https://user-images.githubusercontent.com/38811217/83963357-08aa4400-a8d8-11ea-9438-2e45096145ab.png)